### PR TITLE
fix 2 bugs. 1) issue when there are empty bins in fitting and in pred…

### DIFF
--- a/R/haldensify.R
+++ b/R/haldensify.R
@@ -184,7 +184,8 @@ haldensify <- function(A, W, wts = rep(1, length(A)),
 
   # take column means to have average loss across sequence of lambdas
   loss_mean <- colMeans(density_loss)
-  lambda_loss_min <- lambda_seq[which.min(loss_mean)]
+  lambda_loss_min_idx <- which.min(loss_mean)
+  lambda_loss_min <- lambda_seq[lambda_loss_min_idx]
 
   # fit a HAL regression on the full data set with the CV-selected lambda
   hal_fit <- hal9001::fit_hal(
@@ -194,12 +195,14 @@ haldensify <- function(A, W, wts = rep(1, length(A)),
     use_min = TRUE,
     family = "binomial",
     return_lasso = TRUE,
-    lambda = lambda_loss_min,
+    lambda = lambda_seq,
     fit_glmnet = TRUE,
     standardize = FALSE, # pass to glmnet
     weights = wts_long, # pass to glmnet
     yolo = FALSE
   )
+  # replace coefficients 
+  hal_fit$coefs <- hal_fit$coefs[,lambda_loss_min_idx]
 
   # construct output
   out <- list(

--- a/R/utils.R
+++ b/R/utils.R
@@ -50,20 +50,21 @@ format_long_hazards <- function(A, W, wts = rep(1, length(A)),
     breaks_left <- as.numeric(sub(".(.+),.+", "\\1", levels(bins)))
     breaks_right <- as.numeric(sub(".+,(.+).", "\\1", levels(bins)))
     bin_length <- round(breaks_right - breaks_left, 3)
+    bin_id <- as.numeric(bins)
+    all_bins <- matrix(seq_along(bin_id), ncol = 1)
     # for predict method, only need to assign observations to existing intervals
   } else if (!is.null(breaks)) {
     # NOTE: findInterval() and cut() might return slightly different results...
-    bins <- findInterval(A, breaks, all.inside = TRUE)
+    bin_id <- findInterval(A, breaks, all.inside = TRUE)
+    all_bins <- matrix(seq_along(breaks), ncol = 1)
   } else {
     stop("Combination of arguments `breaks`, `n_bins` incorrectly specified.")
   }
-  bin_id <- as.numeric(bins)
 
+
+  
   # loop over observations to create expanded set of records for each
   reformat_each_obs <- future.apply::future_lapply(seq_along(A), function(i) {
-    # create repeating bin IDs for this subject (these map to intervals)
-    all_bins <- matrix(seq_along(unique(bin_id)), ncol = 1)
-
     # create indicator and "turn on" indicator for interval membership
     bin_indicator <- rep(0, nrow(all_bins))
     bin_indicator[bin_id[i]] <- 1

--- a/tests/testthat/test-density_standard.R
+++ b/tests/testthat/test-density_standard.R
@@ -2,10 +2,11 @@ library(data.table)
 library(ggplot2)
 library(dplyr)
 library(hal9001)
+library(haldensify)
 set.seed(76924)
 
 # simulate data: W ~ Rademacher and A|W ~ N(mu = \pm 1, sd = 0.5)
-n_train <- 1000
+n_train <- 100
 w <- rbinom(n_train, 1, 0.5)
 w[w == 0] <- -1
 a <- rnorm(n_train, w, 0.5)
@@ -14,8 +15,8 @@ a <- rnorm(n_train, w, 0.5)
 mod_haldensify <- haldensify(
   A = a, W = w,
   grid_type = "equal_range",
-  n_bins = 10,
-  lambda_seq = exp(seq(-1, -13, length = 1000))
+  n_bins = 50,
+  lambda_seq = exp(seq(-1, -13, length = 250))
 )
 
 # predictions to recover conditional density of A|W


### PR DESCRIPTION
Messing around and found 2 bugs. 

1) `format_long_hazards` was messing up when there were bins that contained 0 observations. Essentially the call to `unique` in previous line 65 of utils.R was not desirable in this situation as it collapsed bins that didn't have any observations. On the other hand, when `format_long_hazards` was called for predictions, you needed this call to unique. This new fix should work for that. 

2) Sometimes `glmnet` doesn't converge when called with a single lambda and it returns a garbage model that produces garbage predictions. I think you can get more stable behavior by actually passing in a sequence of lambdas, for whatever reason. Then at the very least, if it doesn't converge for the desired lambda, it can return a sane model for a closer lambda. I don't know whether this is a general fix or not, but it resolved the errors in the test I was running. Unfortunately, if users input a long sequence of lambdas this may slow down the procedure, but maybe worth it for the stability.

In any case, I've been very impressed with performance I've seen so far. Will keep testing. 