### PR TITLE
add tuning parameter selection

### DIFF
--- a/R/haldensify.R
+++ b/R/haldensify.R
@@ -253,7 +253,8 @@ haldensify <- function(A, W, wts = rep(1, length(A)),
     bin_sizes = bin_sizes,
     call = call,
     tune_select = tune_select, 
-    select_out = select_out
+    select_out = select_out,
+    range_a = range(A)
   )
   class(out) <- "haldensify"
   return(out)

--- a/R/haldensify.R
+++ b/R/haldensify.R
@@ -112,18 +112,22 @@ cv_haldensify <- function(fold, long_data, wts = rep(1, nrow(long_data)),
 #'  observed intervention values are provided in the previous argument.
 #' @param wts A \code{numeric} vector of observation-level weights. The default
 #'  is to weight all observations equally.
-#' @param grid_type A \code{character} indicating the strategy to be used in
+#' @param grid_type A \code{character} indicating the strategy (or strategies) 
+#'  to be used in
 #'  creating bins along the observed support of the intervention \code{A}. For
 #'  bins of equal range, use "equal_range", consulting the documentation of
 #'  \code{ggplot2::cut_interval} for more information. To ensure each bins has
 #'  the same number of points, use "equal_mass" and consult the documentation of
 #'  \code{ggplot2::cut_number} for details.
 #' @param n_bins Only used if \code{type} is set to \code{"equal_range"} or
-#'  \code{"equal_mass"}. This \code{numeric} value indicates the number of bins
+#'  \code{"equal_mass"}. This \code{numeric} value indicates the number (or 
+#'  numbers)of bins
 #'  that the support of the intervention \code{A} is to be divided into.
 #' @param lambda_seq A \code{numeric} sequence of values of the lambda tuning
 #'  parameter of the Lasso L1 regression, to be passed to \code{glmnet::glmnet}
 #'  through a call to \code{hal9001::fit_hal}.
+#' @param seed Seed to set (needed to ensure proper alignment of CV folds across
+#' n_bins values).
 #'
 #' @importFrom origami make_folds cross_validate
 #' @importFrom hal9001 fit_hal
@@ -134,59 +138,97 @@ haldensify <- function(A, W, wts = rep(1, length(A)),
                        grid_type = c(
                          "equal_range", "equal_mass"
                        ),
-                       n_bins = 10,
-                       lambda_seq = exp(seq(-1, -13, length = 1000))) {
+                       n_bins = c(5, 10),
+                       lambda_seq = exp(seq(-1, -13, length = 1000)),
+                       seed = 9001) {
   # catch input
   call <- match.call(expand.dots = TRUE)
 
+  run_one_tune <- function(n_bins, grid_type){
+    # re-format input data into long hazards structure
+    reformatted_output <- format_long_hazards(
+      A = A, W = W, wts = wts,
+      type = grid_type, n_bins = n_bins
+    )
+    long_data <- reformatted_output$data
+    breakpoints <- reformatted_output$breaks
+    bin_sizes <- reformatted_output$bin_length
+
+    # extract weights from long format data structure
+    wts_long <- long_data$wts
+    long_data[, wts := NULL]
+
+    # make folds with origami
+    set.seed(seed)
+    folds <- origami::make_folds(long_data, cluster_ids = long_data$obs_id)
+
+    # call cross_validate on cv_density function...
+    haldensity <- origami::cross_validate(
+      cv_fun = cv_haldensify,
+      folds = folds,
+      long_data = long_data,
+      wts = wts_long,
+      lambda_seq = lambda_seq,
+      use_future = FALSE,
+      .combine = FALSE
+    )
+
+    # re-organize output cross-validation procedure
+    density_pred_unscaled <- do.call(rbind, haldensity$preds)
+    # re-scale predictions by multiplying by bin width for bin each fails in
+    density_pred_scaled <- apply(density_pred_unscaled, 2, function(x) {
+      pred <- x / bin_sizes[long_data[in_bin == 1, bin_id]]
+      return(pred)
+    })
+    obs_wts <- do.call(c, haldensity$wts)
+
+    # compute loss for the given individual
+    density_loss <- apply(density_pred_scaled, 2, function(x) {
+      pred_weighted <- x * obs_wts
+      loss_weighted <- -log(pred_weighted)
+      return(loss_weighted)
+    })
+
+    # take column means to have average loss across sequence of lambdas
+    loss_mean <- colMeans(density_loss)
+    lambda_loss_min_idx <- which.min(loss_mean)
+    lambda_loss_min <- lambda_seq[lambda_loss_min_idx]
+
+    # format output 
+    out <- list(lambda_loss_min_idx = lambda_loss_min_idx,
+                lambda_loss_min = lambda_loss_min,
+                loss_mean = loss_mean)
+  }
+
+  # run CV hal for all bins X grid_type combos
+  tune_grid <- expand.grid(grid_type = grid_type, n_bins = n_bins,
+                           stringsAsFactors = FALSE)
+
+  # could replace with a future call. 
+  select_out <- mapply(grid_type = tune_grid$grid_type,
+                       n_bins = tune_grid$n_bins, 
+                       FUN = run_one_tune, SIMPLIFY = FALSE)
+
+  # extract n_bins idx with min loss
+  all_loss <- lapply(select_out, "[[", "loss_mean")
+  min_loss_idx <- lapply(all_loss, which.min)
+  min_loss <- lapply(all_loss, min)
+  tune_select <- tune_grid[which.min(min_loss), , drop = FALSE]
+  
   # re-format input data into long hazards structure
   reformatted_output <- format_long_hazards(
     A = A, W = W, wts = wts,
-    type = grid_type, n_bins = n_bins
+    type = tune_select$grid_type, 
+    n_bins = tune_select$n_bins
   )
   long_data <- reformatted_output$data
   breakpoints <- reformatted_output$breaks
   bin_sizes <- reformatted_output$bin_length
-
+  
   # extract weights from long format data structure
   wts_long <- long_data$wts
   long_data[, wts := NULL]
-
-  # make folds with origami
-  folds <- origami::make_folds(long_data, cluster_ids = long_data$obs_id)
-
-  # call cross_validate on cv_density function...
-  haldensity <- origami::cross_validate(
-    cv_fun = cv_haldensify,
-    folds = folds,
-    long_data = long_data,
-    wts = wts_long,
-    lambda_seq = lambda_seq,
-    use_future = FALSE,
-    .combine = FALSE
-  )
-
-  # re-organize output cross-validation procedure
-  density_pred_unscaled <- do.call(rbind, haldensity$preds)
-  # re-scale predictions by multiplying by bin width for bin each fails in
-  density_pred_scaled <- apply(density_pred_unscaled, 2, function(x) {
-    pred <- x / bin_sizes[long_data[in_bin == 1, bin_id]]
-    return(pred)
-  })
-  obs_wts <- do.call(c, haldensity$wts)
-
-  # compute loss for the given individual
-  density_loss <- apply(density_pred_scaled, 2, function(x) {
-    pred_weighted <- x * obs_wts
-    loss_weighted <- -log(pred_weighted)
-    return(loss_weighted)
-  })
-
-  # take column means to have average loss across sequence of lambdas
-  loss_mean <- colMeans(density_loss)
-  lambda_loss_min_idx <- which.min(loss_mean)
-  lambda_loss_min <- lambda_seq[lambda_loss_min_idx]
-
+  
   # fit a HAL regression on the full data set with the CV-selected lambda
   hal_fit <- hal9001::fit_hal(
     X = as.matrix(long_data[, -c(1, 2)]),
@@ -202,14 +244,16 @@ haldensify <- function(A, W, wts = rep(1, length(A)),
     yolo = FALSE
   )
   # replace coefficients 
-  hal_fit$coefs <- hal_fit$coefs[,lambda_loss_min_idx]
-
+  hal_fit$coefs <- hal_fit$coefs[, select_out[[which.min(min_loss)]]$lambda_loss_min_idx]
+  
   # construct output
   out <- list(
     hal_fit = hal_fit,
     breaks = breakpoints,
     bin_sizes = bin_sizes,
-    call = call
+    call = call,
+    tune_select = tune_select, 
+    select_out = select_out
   )
   class(out) <- "haldensify"
   return(out)

--- a/R/predict.R
+++ b/R/predict.R
@@ -55,6 +55,9 @@ predict.haldensify <- function(object, ..., new_A, new_W) {
   density_pred_scaled <- density_pred_unscaled /
     object$bin_sizes[long_data_pred[in_bin == 1, bin_id]]
 
+  # truncate predictions outside range of observed A
+  density_pred_scaled[new_A < object$range_a[1] | new_A > object$range_a[2]] <- 0
+  
   # output
   return(density_pred_scaled)
 }

--- a/man/haldensify.Rd
+++ b/man/haldensify.Rd
@@ -5,8 +5,8 @@
 \title{Cross-validated conditional density estimation with HAL}
 \usage{
 haldensify(A, W, wts = rep(1, length(A)), grid_type = c("equal_range",
-  "equal_mass"), n_bins = 10, lambda_seq = exp(seq(-1, -13, length =
-  1000)))
+  "equal_mass"), n_bins = c(5, 10), lambda_seq = exp(seq(-1, -13,
+  length = 1000)), seed = 9001)
 }
 \arguments{
 \item{A}{The \code{numeric} vector or similar of the observed values of an
@@ -19,7 +19,8 @@ observed intervention values are provided in the previous argument.}
 \item{wts}{A \code{numeric} vector of observation-level weights. The default
 is to weight all observations equally.}
 
-\item{grid_type}{A \code{character} indicating the strategy to be used in
+\item{grid_type}{A \code{character} indicating the strategy (or strategies) 
+to be used in
 creating bins along the observed support of the intervention \code{A}. For
 bins of equal range, use "equal_range", consulting the documentation of
 \code{ggplot2::cut_interval} for more information. To ensure each bins has
@@ -27,12 +28,16 @@ the same number of points, use "equal_mass" and consult the documentation of
 \code{ggplot2::cut_number} for details.}
 
 \item{n_bins}{Only used if \code{type} is set to \code{"equal_range"} or
-\code{"equal_mass"}. This \code{numeric} value indicates the number of bins
+\code{"equal_mass"}. This \code{numeric} value indicates the number (or 
+numbers)of bins
 that the support of the intervention \code{A} is to be divided into.}
 
 \item{lambda_seq}{A \code{numeric} sequence of values of the lambda tuning
 parameter of the Lasso L1 regression, to be passed to \code{glmnet::glmnet}
 through a call to \code{hal9001::fit_hal}.}
+
+\item{seed}{Seed to set (needed to ensure proper alignment of CV folds across
+n_bins values).}
 }
 \description{
 Cross-validated conditional density estimation with HAL

--- a/sandbox/playing_around.R
+++ b/sandbox/playing_around.R
@@ -1,0 +1,44 @@
+devtools::load_all("~/Dropbox/R/haldensify")
+
+library(data.table)
+library(ggplot2)
+library(dplyr)
+library(hal9001)
+library(haldensify)
+set.seed(76924)
+
+# simulate data: W ~ Rademacher and A|W ~ N(mu = \pm 1, sd = 0.5)
+n_train <- 100
+w <- runif(n_train, -4, 4)
+a <- rnorm(n_train, w, 0.5)
+
+# learn relationship A|W using HAL-based density estimation procedure
+# tune over different choices of n_bins and grid_type
+mod_haldensify <- haldensify(
+  A = a, W = w,
+  grid_type = c("equal_range","equal_mass"),
+  n_bins = c(5, 10),
+  lambda_seq = exp(seq(-1, -13, length = 250))
+)
+
+# predictions to recover conditional density of A|W
+new_a <- seq(-8, 8, by = 0.01)
+w_val <- c(-3, -1, 1, 3)
+add_line <- function(a_val = seq(-5, 5, by = 0.01),
+                     w_val = 0, new_plot = TRUE, 
+                     col_true = 1, col_est = 1, ...){
+	pred <- predict(mod_haldensify,
+  new_A = a_val, new_W = rep(w_val, length(a_val)))
+	if(new_plot){
+		plot(0, 0, pch = "", xlim = range(a_val), ylim = c(0, max(pred)*1.10),
+		     xlab = "a", ylab = "Density")
+	}
+	# add true density
+	lines(x = a_val, y = dnorm(a_val, w_val, 0.5), lty = 2, col = col_true)
+	# add predicted density
+	lines(x = a_val, y = pred, lty = 1, col = col_est)
+}
+
+add_line(col_true = 1, col_est = 1)
+add_line(w_val = -2, new_plot = FALSE, col_true = 2, col_est = 2)
+add_line(w_val = 2, new_plot = FALSE, col_true = 4, col_est = 4)


### PR DESCRIPTION
This PR adds functionality for selecting `n_bins` and `grid_type` using cross-validation. 

Basically, I wrapper up all the nice code you'd already written into a CV routine that loops over all combinations of `n_bins` and `grid_type` that a user specifies. Then we fit the final model based on that binning scheme. 

Misc. notes:
- The helper function `run_one_tune` is defined in `haldensify`, but could be pulled out to be its own function if that was desirable. 
- The function now return information on the loss across different lambdas for each choice of `n_bins` and `grid_type` in the `tune_select` and `select_out` slots. 
- I added a sandbox folder for storing test `R` scripts as we start to play around more and look for edge cases to debug. 
