### PR TITLE
Drop `transparent` futures in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,18 @@ warnings_are_errors: true
 r_build_args: '--no-manual'
 r_check_args: '--no-build-vignettes --no-manual'
 
+addons:
+  apt:
+    packages:
+      - libgit2-dev
+
 r:
   - oldrel
   - release
   - devel
 
-before_install:
-  #- Rscript -e 'update.packages(ask = FALSE)'
-
 r_packages:
+  - usethis
   - devtools
   - data.table
   - sessioninfo

--- a/tests/testthat/test-density_standard.R
+++ b/tests/testthat/test-density_standard.R
@@ -3,7 +3,6 @@ library(ggplot2)
 library(dplyr)
 library(hal9001)
 library(future)
-plan(transparent)
 set.seed(76924)
 
 # simulate data: W ~ Rademacher and A|W ~ N(mu = \pm 1, sd = 0.5)

--- a/tests/testthat/test-density_weights.R
+++ b/tests/testthat/test-density_weights.R
@@ -3,7 +3,6 @@ library(ggplot2)
 library(dplyr)
 library(hal9001)
 library(future)
-plan(transparent)
 set.seed(76921)
 
 # data simulation


### PR DESCRIPTION
Drop specification of `plan(transparent)` with futures in unit tests as per #19.