### PR TITLE
bootstrap and streamlining

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: haldensify
 Title: Highly Adaptive Lasso Conditional Density Estimation
-Version: 0.0.7
+Version: 0.0.8
 Authors@R: c(
     person("Nima", "Hejazi", email = "nh@nimahejazi.org",
            role = c("aut", "cre", "cph"),

--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,4 @@ buildfast:
 style:
 	Rscript -e "styler::style_pkg()"
 
-pr: style doc check site
+pr: style check site

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@ As of January 2021:
 * Addition of arugment `...` to `haldensify()` so that arbitrary arguments can
   be passed to `fit_hal()` for density estimation, when not already specified
   as other arguments of the `haldensify()` constructor.
+* Remove the unnecessary argument `use_future`, specifying parallel evaluation
+  in a note instead.
 
 # haldensify 0.0.7
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# haldensify 0.0.8
+
+As of January 2021:
+* [TO FILL IN]
+* [TO FILL IN]
+
 # haldensify 0.0.7
 
 As of January 2021:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 # haldensify 0.0.8
 
 As of January 2021:
+* Addition of a `basis_list` argument to `haldensify()`, allowing for a HAL
+  basis produced by `fit_hal()` to be passed in to the HAL regression for
+  density estimation. This facilitates reduced computational overhead when
+  requiring external cross-validation of nuisance functions (e.g., CV-TMLE) as
+  well as working with bootstrap samples.
+* [TO FILL IN]
 * [TO FILL IN]
 * [TO FILL IN]
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,10 @@ As of January 2021:
   as other arguments of the `haldensify()` constructor.
 * Remove the unnecessary argument `use_future`, specifying parallel evaluation
   in a note instead.
+* Add an option `"all"` to the `lambda_select` argument of the `predict()`
+  method, allowing for predictions on the full (non-truncated) sequence of
+  lambdas fitted on to be returned.
+* Change truncation option in `predict()` method to 1/n instead of zero.
 
 # haldensify 0.0.7
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,25 @@
 # haldensify 0.0.8
 
 As of January 2021:
-* Addition of a `basis_list` argument to `haldensify()`, allowing for a HAL
-  basis produced by `fit_hal()` to be passed in to the HAL regression for
+* Addition of argument `hal_basis_list` to `haldensify()`, allowing for a HAL
+  basis produced by `fit_hal()` to be passed into the HAL regression used for
   density estimation. This facilitates reduced computational overhead when
   requiring external cross-validation of nuisance functions (e.g., CV-TMLE) as
   well as working with bootstrap samples.
-* [TO FILL IN]
-* [TO FILL IN]
-* [TO FILL IN]
+* Addition of argument `hal_max_degree` to `haldensify()`, allowing for control
+  of the highest degree of interactions considered in the HAL model for density
+  estimation. Like the above, this can reduce computational overhead.
+* Fix a minor bug in `haldensify()` by passing `cv_folds` to the `n_folds`
+  argument of `fit_hal()` when fitting HAL regression for density estimation.
+  Previously, `cv_folds` was only used in constructing cross-validation (CV)
+  folds for choosing tuning parameters, but the subsequent HAL regression was
+  fiex to use the default number of folds specified in `fit_hal()` to choose
+  the regularization parameter of the HAL regression for density estimation.
+  Now, both CV to choose density estimation tuning parameters and CV to choose
+  the lasso tuning parameter use the same number of folds.
+* Addition of arugment `...` to `haldensify()` so that arbitrary arguments can
+  be passed to `fit_hal()` for density estimation, when not already specified
+  as other arguments of the `haldensify()` constructor.
 
 # haldensify 0.0.7
 

--- a/R/haldensify.R
+++ b/R/haldensify.R
@@ -85,6 +85,7 @@ cv_haldensify <- function(fold, long_data, wts = rep(1, nrow(long_data)),
     density_pred_this_obs <-
       map_hazard_to_density(hazard_pred_single_obs = hazard_pred_this_obs)
 
+    # output estimated density for the given observation
     return(density_pred_this_obs)
   })
 
@@ -142,6 +143,13 @@ cv_haldensify <- function(fold, long_data, wts = rep(1, nrow(long_data)),
 #'  uses a cross-validation selector to choose between 10 and 25 bins.
 #' @param cv_folds A \code{numeric} indicating the number of cross-validation
 #'  folds to be used in fitting the sequence of HAL conditional density models.
+#' @param basis_list A \code{list} consisting of a pre-constructed set of HAL
+#'  basis functions, as produced by \code{\link[hal9001]{fit_hal}}. The default
+#'  of \code{NULL} results in creating such a set of basis functions. When this
+#'  is provided instead, it is passed directly to the HAL model fitted to the
+#'  augmented (repeated measures) data structure, resulting in a much lowered
+#'  computational cost. This is useful, for example, in fitting HAL conditional
+#'  density estimates on cross-validated datasets or bootstrap samples.
 #' @param lambda_seq A \code{numeric} sequence of values of the regularization
 #'  parameter of Lasso regression; passed to \code{\link[hal9001]{fit_hal}}.
 #' @param use_future A \code{logical} indicating whether to attempt to use
@@ -179,6 +187,7 @@ haldensify <- function(A,
                        grid_type = "equal_range",
                        n_bins = c(10, 25),
                        cv_folds = 5,
+                       basis_list = NULL,
                        lambda_seq = exp(seq(-1, -13, length = 1000)),
                        use_future = FALSE) {
   # if W is set to NULL, create a constant conditioning set
@@ -249,10 +258,11 @@ haldensify <- function(A,
     max_degree = NULL,
     fit_type = "glmnet",
     family = "binomial",
+    basis_list = basis_list,
     lambda = lambda_seq,
     cv_select = FALSE,
     standardize = FALSE, # passed to glmnet
-    weights = wts_long, # passed to glmnet
+    weights = wts_long,  # passed to glmnet
     yolo = FALSE
   )
 
@@ -274,7 +284,7 @@ haldensify <- function(A,
 
 #' Fit conditional density estimation for a sequence of HAL models
 #'
-#' @details Estimation of the conditional density A|W via a cross-validated
+#' @details Estimation of the conditional density of A|W via a cross-validated
 #'  highly adaptive lasso, used to estimate the conditional hazard of failure
 #'  in a given bin over the support of A.
 #'

--- a/R/haldensify.R
+++ b/R/haldensify.R
@@ -265,7 +265,7 @@ haldensify <- function(A,
     cv_select = FALSE,
     ...,
     standardize = FALSE, # passed to glmnet
-    weights = wts_long,  # passed to glmnet
+    weights = wts_long, # passed to glmnet
     yolo = FALSE
   )
 

--- a/R/haldensify.R
+++ b/R/haldensify.R
@@ -268,6 +268,7 @@ haldensify <- function(A,
     weights = wts_long,  # passed to glmnet
     yolo = FALSE
   )
+
   # construct output
   out <- list(
     hal_fit = hal_fit,

--- a/R/haldensify.R
+++ b/R/haldensify.R
@@ -1,6 +1,6 @@
 utils::globalVariables(c("in_bin", "bin_id"))
 
-#' Conditional density estimation with HAL in a single cross-validation fold
+#' HAL Conditional Density Estimation in a Cross-validation Fold
 #'
 #' @details Estimates the conditional density of A|W for a subset of the full
 #'  set of observations based on the inputted structure of the cross-validation
@@ -111,7 +111,7 @@ cv_haldensify <- function(fold, long_data, wts = rep(1, nrow(long_data)),
 
 ###############################################################################
 
-#' Cross-validated conditional density estimation with HAL
+#' Cross-validated HAL Conditional Density Estimation
 #'
 #' @details Estimation of the conditional density A|W through using the highly
 #'  adaptive lasso to estimate the conditional hazard of failure in a given
@@ -149,7 +149,7 @@ cv_haldensify <- function(fold, long_data, wts = rep(1, nrow(long_data)),
 #'  is provided instead, it is passed directly to the HAL model fitted to the
 #'  augmented (repeated measures) data structure, resulting in a much lowered
 #'  computational cost. This is useful, for example, in fitting HAL conditional
-#'  density estimates on cross-validated datasets or bootstrap samples.
+#'  density estimates with external cross-validation or bootstrap samples.
 #' @param lambda_seq A \code{numeric} sequence of values of the regularization
 #'  parameter of Lasso regression; passed to \code{\link[hal9001]{fit_hal}}.
 #' @param use_future A \code{logical} indicating whether to attempt to use
@@ -282,7 +282,7 @@ haldensify <- function(A,
 
 ###############################################################################
 
-#' Fit conditional density estimation for a sequence of HAL models
+#' Fit Conditional Density Estimation for a Sequence of HAL Models
 #'
 #' @details Estimation of the conditional density of A|W via a cross-validated
 #'  highly adaptive lasso, used to estimate the conditional hazard of failure

--- a/R/predict.R
+++ b/R/predict.R
@@ -1,6 +1,6 @@
 utils::globalVariables(c("wts"))
 
-#' Prediction method for HAL-based conditional density estimation
+#' Prediction Method for HAL Conditional Density Estimation
 #'
 #' @details Method for computing and extracting predictions of the conditional
 #'  density estimates based on the highly adaptive lasso estimator, returned as

--- a/R/predict.R
+++ b/R/predict.R
@@ -48,7 +48,7 @@ utils::globalVariables(c("wts"))
 #' new_w <- rep(0, length(new_a))
 #' pred_dens <- predict(mod_haldensify, new_A = new_a, new_W = new_w)
 predict.haldensify <- function(object, ..., new_A, new_W,
-                               lambda_select = c("cv", "undersmooth")) {
+                               lambda_select = c("cv", "undersmooth", "all")) {
   # set default selection procedure to the cross-validation selector
   lambda_select <- match.arg(lambda_select)
 
@@ -107,15 +107,18 @@ predict.haldensify <- function(object, ..., new_A, new_W,
 
   # truncate predictions outside range of observed A
   outside_range <- new_A < object$range_a[1] | new_A > object$range_a[2]
-  density_pred_rescaled[outside_range, ] <- 0
+  density_pred_rescaled[outside_range, ] <- 1 / length(new_A)
 
   # return predicted densities only for CV-selected or undersmoothed lambdas
   cv_lambda_idx <- object$cv_tuning_results$lambda_loss_min_idx
   if (lambda_select == "cv") {
     density_pred_rescaled <- density_pred_rescaled[, cv_lambda_idx]
-  } else {
+  } else if (lambda_select == "undersmooth") {
     usm_lambda_idx <- cv_lambda_idx:length(object$cv_tuning_results$lambda_seq)
     density_pred_rescaled <- density_pred_rescaled[, usm_lambda_idx]
+  } else if (lambda_select == "all") {
+    # pass -- just return CDE predictions for all lambda
+    TRUE
   }
 
   # output

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,10 +1,12 @@
-#' Generate long format hazards data for pooled hazards estimation
+#' Generate Augmented (Long Format) Data for Pooled Hazards Regression
 #'
-#' @details Generates a long-form dataset that represents each observation in
-#'  terms of repeated measures across discretized bins derived from selecting
-#'  break points over the support of A. This repeated measures dataset is
-#'  suitable for estimating the hazard of failing in a particular bin over A
-#'  using a highly adaptive lasso classification model.
+#' @details Generates an augmented (long format, or repeated measures) dataset
+#'  that includes multiple records for each observation, a single record for
+#'  each discretized bin up to and including the bin in which a given observed
+#'  value of A falls. Such bins are derived from selecting break points over
+#'  the support of A. This repeated measures dataset is suitable for estimating
+#'  the hazard of failing in a particular bin over A using a highly adaptive
+#'  lasso (or other) classification model.
 #'
 #' @param A The \code{numeric} vector or similar of the observed values of an
 #'  intervention for a group of observational units of interest.
@@ -146,7 +148,7 @@ format_long_hazards <- function(A, W, wts = rep(1, length(A)),
 
 ###############################################################################
 
-#' Map a predicted hazard to a predicted density for a single observation
+#' Map Predicted Hazard to Predicted Density for a Single Observation
 #'
 #' @details For a single observation, map a predicted hazard of failure (as an
 #'  occurrence in a particular bin, under a given partitioning of the support)

--- a/README.Rmd
+++ b/README.Rmd
@@ -76,8 +76,6 @@ A simple example illustrates how `haldensify` may be used to construct
 conditional density estimates:
 
 ```{r example, message=FALSE, warning=FALSE}
-library(tidyverse)
-library(data.table)
 library(haldensify)
 set.seed(76924)
 
@@ -87,7 +85,7 @@ w <- runif(n_train, -4, 4)
 a <- rnorm(n_train, w, 0.25)
 
 # HAL-based density estimate of A|W
-mod_haldensify <- haldensify(
+haldensify_fit <- haldensify(
   A = a, W = w,
   n_bins = c(5, 20),
   grid_type = "equal_range",
@@ -95,7 +93,7 @@ mod_haldensify <- haldensify(
 )
 
 # use the built-in predict method to get predictions
-pred_haldensify <- predict(mod_haldensify, new_A = a, new_W = w)
+pred_haldensify <- predict(haldensify_fit, new_A = a, new_W = w)
 ```
 
 ---

--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,15 @@
 # `haldensify` development
 
-* Add example of working with bootstrap samples, e.g., using `rsample`.
-* Add a `plot()` method to more easily visualize how empirical risk changes
-  across the sequence of regularization parameter values.
-* Remove `use_future` argument to `haldensify()`, instead reducing to calling
-  `future_mapply()`, with sequential evaluation under `plan(sequential)`.
-* Add a new argument to `haldensify()` to allow normalization of the density
-  estimates (summing to 1) to improve estimation stability.
-* Add an `ipw_est()` function for constructing IPW estimators of the mean
+- [x] Add `...` args to `haldensify()` to allow arbitrary arguments to be
+  passed directly to `fit_hal()`.
+- [ ] Remove `use_future` argument to `haldensify()`, instead reducing to
+  calling `future_mapply()`, with sequential evaluation via `plan(sequential)`.
+- [ ] Add a `plot()` method to more easily visualize how empirical risk changes
+  across the sequence of explored regularization parameter values.
+- [ ] Add example of working with bootstrap samples, e.g., using
+  [`rsample`](https://rsample.tidymodels.org/reference/bootstraps.html).
+- [ ] Add an `ipw_est()` function for constructing IPW estimators of the mean
   counterfactual outcome of a stochastic shift intervention via `haldensify`.
+- [ ] Add an argument to `haldensify()` to allow normalization of the density
+  estimates to improve estimation stability. Note that this normalized density
+  is actually g(A|W)/g(A), instead of the currently estimated g(A|W).

--- a/TODO.md
+++ b/TODO.md
@@ -4,10 +4,10 @@
   passed directly to `fit_hal()`.
 - [x] Remove `use_future` argument to `haldensify()`, instead reducing to
   calling `future_mapply()`, with sequential evaluation via `plan(sequential)`.
+- [x] Add example of working with bootstrap samples, e.g., using
+  [`rsample`](https://rsample.tidymodels.org/reference/bootstraps.html).
 - [ ] Add a `plot()` method to more easily visualize how empirical risk changes
   across the sequence of explored regularization parameter values.
-- [ ] Add example of working with bootstrap samples, e.g., using
-  [`rsample`](https://rsample.tidymodels.org/reference/bootstraps.html).
 - [ ] Add an `ipw_est()` function for constructing IPW estimators of the mean
   counterfactual outcome of a stochastic shift intervention via `haldensify`.
 - [ ] Add an argument to `haldensify()` to allow normalization of the density

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 - [x] Add `...` args to `haldensify()` to allow arbitrary arguments to be
   passed directly to `fit_hal()`.
-- [ ] Remove `use_future` argument to `haldensify()`, instead reducing to
+- [x] Remove `use_future` argument to `haldensify()`, instead reducing to
   calling `future_mapply()`, with sequential evaluation via `plan(sequential)`.
 - [ ] Add a `plot()` method to more easily visualize how empirical risk changes
   across the sequence of explored regularization parameter values.

--- a/TODO.md
+++ b/TODO.md
@@ -2,3 +2,9 @@
 
 * Add a `plot()` method to more easily visualize how empirical risk changes
   across the sequence of regularization parameter values.
+* Add example of working with bootstrap samples, e.g., using `rsample`.
+* Add a `ipw_est()` function for constructing IPW estimators of the mean
+  counterfactual outocme of a stochastic shift intervention via `haldensify`.
+* Remove the `use_future` argument to `haldensify()`, instead reducing to just
+  using `future_mapply()`, which should allow sequential evaluation under
+  `plan(sequential)`.

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,11 @@
-# haldensify development
+# `haldensify` development
 
+* Add example of working with bootstrap samples, e.g., using `rsample`.
 * Add a `plot()` method to more easily visualize how empirical risk changes
   across the sequence of regularization parameter values.
-* Add example of working with bootstrap samples, e.g., using `rsample`.
-* Add a `ipw_est()` function for constructing IPW estimators of the mean
-  counterfactual outocme of a stochastic shift intervention via `haldensify`.
-* Remove the `use_future` argument to `haldensify()`, instead reducing to just
-  using `future_mapply()`, which should allow sequential evaluation under
-  `plan(sequential)`.
+* Remove `use_future` argument to `haldensify()`, instead reducing to calling
+  `future_mapply()`, with sequential evaluation under `plan(sequential)`.
+* Add a new argument to `haldensify()` to allow normalization of the density
+  estimates (summing to 1) to improve estimation stability.
+* Add an `ipw_est()` function for constructing IPW estimators of the mean
+  counterfactual outcome of a stochastic shift intervention via `haldensify`.

--- a/man/cv_haldensify.Rd
+++ b/man/cv_haldensify.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/haldensify.R
 \name{cv_haldensify}
 \alias{cv_haldensify}
-\title{Conditional density estimation with HAL in a single cross-validation fold}
+\title{HAL Conditional Density Estimation in a Cross-validation Fold}
 \usage{
 cv_haldensify(
   fold,
@@ -33,7 +33,7 @@ A \code{list}, containing density predictions, observations IDs,
  density estimation on a single fold of the overall data.
 }
 \description{
-Conditional density estimation with HAL in a single cross-validation fold
+HAL Conditional Density Estimation in a Cross-validation Fold
 }
 \details{
 Estimates the conditional density of A|W for a subset of the full

--- a/man/fit_haldensify.Rd
+++ b/man/fit_haldensify.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/haldensify.R
 \name{fit_haldensify}
 \alias{fit_haldensify}
-\title{Fit conditional density estimation for a sequence of HAL models}
+\title{Fit Conditional Density Estimation for a Sequence of HAL Models}
 \usage{
 fit_haldensify(
   A,
@@ -47,10 +47,10 @@ A \code{list}, containing density predictions for the sequence of
  sequence of fitted HAL models.
 }
 \description{
-Fit conditional density estimation for a sequence of HAL models
+Fit Conditional Density Estimation for a Sequence of HAL Models
 }
 \details{
-Estimation of the conditional density A|W via a cross-validated
+Estimation of the conditional density of A|W via a cross-validated
  highly adaptive lasso, used to estimate the conditional hazard of failure
  in a given bin over the support of A.
 }

--- a/man/format_long_hazards.Rd
+++ b/man/format_long_hazards.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/utils.R
 \name{format_long_hazards}
 \alias{format_long_hazards}
-\title{Generate long format hazards data for pooled hazards estimation}
+\title{Generate Augmented (Long Format) Data for Pooled Hazards Regression}
 \usage{
 format_long_hazards(
   A,
@@ -49,12 +49,14 @@ A \code{list} containing the break points used in dividing the
  observation, and observation-level weights.
 }
 \description{
-Generate long format hazards data for pooled hazards estimation
+Generate Augmented (Long Format) Data for Pooled Hazards Regression
 }
 \details{
-Generates a long-form dataset that represents each observation in
- terms of repeated measures across discretized bins derived from selecting
- break points over the support of A. This repeated measures dataset is
- suitable for estimating the hazard of failing in a particular bin over A
- using a highly adaptive lasso classification model.
+Generates an augmented (long format, or repeated measures) dataset
+ that includes multiple records for each observation, a single record for
+ each discretized bin up to and including the bin in which a given observed
+ value of A falls. Such bins are derived from selecting break points over
+ the support of A. This repeated measures dataset is suitable for estimating
+ the hazard of failing in a particular bin over A using a highly adaptive
+ lasso (or other) classification model.
 }

--- a/man/haldensify.Rd
+++ b/man/haldensify.Rd
@@ -9,10 +9,12 @@ haldensify(
   W,
   wts = rep(1, length(A)),
   grid_type = "equal_range",
-  n_bins = c(10, 25),
+  n_bins = c(3, 5, 10),
   cv_folds = 5,
-  basis_list = NULL,
   lambda_seq = exp(seq(-1, -13, length = 1000)),
+  hal_basis_list = NULL,
+  hal_max_degree = NULL,
+  ...,
   use_future = FALSE
 )
 }
@@ -47,16 +49,29 @@ uses a cross-validation selector to choose between 10 and 25 bins.}
 \item{cv_folds}{A \code{numeric} indicating the number of cross-validation
 folds to be used in fitting the sequence of HAL conditional density models.}
 
-\item{basis_list}{A \code{list} consisting of a pre-constructed set of HAL
-basis functions, as produced by \code{\link[hal9001]{fit_hal}}. The default
-of \code{NULL} results in creating such a set of basis functions. When this
-is provided instead, it is passed directly to the HAL model fitted to the
+\item{lambda_seq}{A \code{numeric} sequence of values of the regularization
+parameter of Lasso regression; passed to \code{\link[hal9001]{fit_hal}} via
+its argument \code{lambda}, itself passed to \code{\link[glmnet]{glmnet}}.}
+
+\item{hal_basis_list}{A \code{list} consisting of a preconstructed set of
+HAL basis functions, as produced by \code{\link[hal9001]{fit_hal}}. The
+default of \code{NULL} results in creating such a set of basis functions.
+When specified, this is passed directly to the HAL model fitted upon the
 augmented (repeated measures) data structure, resulting in a much lowered
 computational cost. This is useful, for example, in fitting HAL conditional
 density estimates with external cross-validation or bootstrap samples.}
 
-\item{lambda_seq}{A \code{numeric} sequence of values of the regularization
-parameter of Lasso regression; passed to \code{\link[hal9001]{fit_hal}}.}
+\item{hal_max_degree}{Either \code{NULL} (the default) or a \code{numeric}
+indicating the maximum number of covariate interactions to be considered in
+the construction of HAL basis functions. If \code{NULL}, up to the highest
+order interaction is considered; otherwise, all interactions up to the
+specified order are considered. When specified, this is passed directly to
+the \code{max_degree} argument of \code{\link[hal9001]{fit_hal}}.}
+
+\item{...}{Additional (optional) arguments of \code{\link[hal9001]{fit_hal}}
+that may be used to control fitting of the HAL regression model. Possible
+choices include \code{use_min}, \code{reduce_basis}, \code{return_lasso},
+and \code{return_x_basis}, but this list is not exhaustive.}
 
 \item{use_future}{A \code{logical} indicating whether to attempt to use
 parallelization based on \pkg{future} and \pkg{future.apply}. If set to

--- a/man/haldensify.Rd
+++ b/man/haldensify.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/haldensify.R
 \name{haldensify}
 \alias{haldensify}
-\title{Cross-validated conditional density estimation with HAL}
+\title{Cross-validated HAL Conditional Density Estimation}
 \usage{
 haldensify(
   A,
@@ -11,6 +11,7 @@ haldensify(
   grid_type = "equal_range",
   n_bins = c(10, 25),
   cv_folds = 5,
+  basis_list = NULL,
   lambda_seq = exp(seq(-1, -13, length = 1000)),
   use_future = FALSE
 )
@@ -46,6 +47,14 @@ uses a cross-validation selector to choose between 10 and 25 bins.}
 \item{cv_folds}{A \code{numeric} indicating the number of cross-validation
 folds to be used in fitting the sequence of HAL conditional density models.}
 
+\item{basis_list}{A \code{list} consisting of a pre-constructed set of HAL
+basis functions, as produced by \code{\link[hal9001]{fit_hal}}. The default
+of \code{NULL} results in creating such a set of basis functions. When this
+is provided instead, it is passed directly to the HAL model fitted to the
+augmented (repeated measures) data structure, resulting in a much lowered
+computational cost. This is useful, for example, in fitting HAL conditional
+density estimates with external cross-validation or bootstrap samples.}
+
 \item{lambda_seq}{A \code{numeric} sequence of values of the regularization
 parameter of Lasso regression; passed to \code{\link[hal9001]{fit_hal}}.}
 
@@ -64,7 +73,7 @@ Object of class \code{haldensify}, containing a fitted
  the range of \code{A}.
 }
 \description{
-Cross-validated conditional density estimation with HAL
+Cross-validated HAL Conditional Density Estimation
 }
 \details{
 Estimation of the conditional density A|W through using the highly

--- a/man/haldensify.Rd
+++ b/man/haldensify.Rd
@@ -14,8 +14,7 @@ haldensify(
   lambda_seq = exp(seq(-1, -13, length = 1000)),
   hal_basis_list = NULL,
   hal_max_degree = NULL,
-  ...,
-  use_future = FALSE
+  ...
 )
 }
 \arguments{
@@ -72,12 +71,6 @@ the \code{max_degree} argument of \code{\link[hal9001]{fit_hal}}.}
 that may be used to control fitting of the HAL regression model. Possible
 choices include \code{use_min}, \code{reduce_basis}, \code{return_lasso},
 and \code{return_x_basis}, but this list is not exhaustive.}
-
-\item{use_future}{A \code{logical} indicating whether to attempt to use
-parallelization based on \pkg{future} and \pkg{future.apply}. If set to
-\code{TRUE}, \code{\link[future.apply]{future_mapply}} will be used in
-place of \code{mapply}. When set to \code{TRUE}, a parallelization scheme
-must be specified externally by a call to \code{\link[future]{plan}}.}
 }
 \value{
 Object of class \code{haldensify}, containing a fitted
@@ -96,6 +89,12 @@ Estimation of the conditional density A|W through using the highly
  bin over the support of A. Cross-validation is used to select the optimal
  value of the penalization parameters, based on minimization of the weighted
  log-likelihood loss for a density.
+}
+\note{
+Parallel evaluation of the cross-validation procedure to select tuning
+ parameters for density estimation may be invoked via the framework exposed
+ in the \pkg{future} ecosystem. Specifically, set \code{\link[future]{plan}}
+ for \code{\link[future.apply]{future_mapply}} to be used internally.
 }
 \examples{
 # simulate data: W ~ U[-4, 4] and A|W ~ N(mu = W, sd = 0.5)

--- a/man/map_hazard_to_density.Rd
+++ b/man/map_hazard_to_density.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/utils.R
 \name{map_hazard_to_density}
 \alias{map_hazard_to_density}
-\title{Map a predicted hazard to a predicted density for a single observation}
+\title{Map Predicted Hazard to Predicted Density for a Single Observation}
 \usage{
 map_hazard_to_density(hazard_pred_single_obs)
 }
@@ -21,7 +21,7 @@ A \code{matrix} composed of a single row and a number of columns
  given observation, re-mapped from the hazard scale.
 }
 \description{
-Map a predicted hazard to a predicted density for a single observation
+Map Predicted Hazard to Predicted Density for a Single Observation
 }
 \details{
 For a single observation, map a predicted hazard of failure (as an

--- a/man/predict.haldensify.Rd
+++ b/man/predict.haldensify.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/predict.R
 \name{predict.haldensify}
 \alias{predict.haldensify}
-\title{Prediction method for HAL-based conditional density estimation}
+\title{Prediction Method for HAL Conditional Density Estimation}
 \usage{
 \method{predict}{haldensify}(object, ..., new_A, new_W, lambda_select = c("cv", "undersmooth"))
 }
@@ -35,7 +35,7 @@ A \code{numeric} vector of predicted conditional density values from
  a fitted \code{haldensify} object.
 }
 \description{
-Prediction method for HAL-based conditional density estimation
+Prediction Method for HAL Conditional Density Estimation
 }
 \details{
 Method for computing and extracting predictions of the conditional

--- a/man/predict.haldensify.Rd
+++ b/man/predict.haldensify.Rd
@@ -4,7 +4,13 @@
 \alias{predict.haldensify}
 \title{Prediction Method for HAL Conditional Density Estimation}
 \usage{
-\method{predict}{haldensify}(object, ..., new_A, new_W, lambda_select = c("cv", "undersmooth"))
+\method{predict}{haldensify}(
+  object,
+  ...,
+  new_A,
+  new_W,
+  lambda_select = c("cv", "undersmooth", "all")
+)
 }
 \arguments{
 \item{object}{An object of class \code{\link{haldensify}}, containing the

--- a/sandbox/bootstrap_haldensify.R
+++ b/sandbox/bootstrap_haldensify.R
@@ -14,7 +14,7 @@ Q0 <- function(A, W1, W2, W3) {
 }
 
 # simulate data
-n_samp <- 500
+n_samp <- 100
 W1 <- rbinom(n_samp, 1, 0.6)
 W2 <- rbinom(n_samp, 1, 0.2)
 W3 <- rpois(n_samp, 3)
@@ -42,7 +42,7 @@ haldensify_pred <- predict(
 
 # construct bootstrap samples and fit haldensify on each of these resamples
 # NOTE: pass in CV-selected tuning parameters and basis list for HAL fits
-n_boot <- 5
+n_boot <- 100
 boot_samples <- bootstraps(data_obs, times = n_boot)
 haldensify_pred_boot <- lapply(boot_samples$splits, function(data_split) {
   # get bootstrap sample
@@ -80,7 +80,6 @@ haldensify_pred_boot_usm <- lapply(haldensify_pred_boot, function(hal_pred) {
 })
 
 # pack density estimates on original and bootstrap samples into array
-test <- abind(haldensify_pred,
-              unlist(haldensify_pred_boot_usm, recursive = FALSE),
-              along = 0)
+halcde_pred <- abind(c(list(haldensify_pred), haldensify_pred_boot_usm),
+                     along = 3)
 

--- a/sandbox/bootstrap_haldensify.R
+++ b/sandbox/bootstrap_haldensify.R
@@ -1,0 +1,86 @@
+library(tidymodels)
+library(haldensify)
+library(abind)
+
+# set up simple DGP
+g0 <- function(W1, W2, W3) {
+  mu <- 2 * W1 - W2 - W1 * W2
+  sigma2 <- 4
+  return(list(mu = mu, sigma2 = sigma2))
+}
+# define outcome mechanism
+Q0 <- function(A, W1, W2, W3) {
+  plogis(3 * A + W1 + W2 - 2 * W3 - W1 * W3)
+}
+
+# simulate data
+n_samp <- 500
+W1 <- rbinom(n_samp, 1, 0.6)
+W2 <- rbinom(n_samp, 1, 0.2)
+W3 <- rpois(n_samp, 3)
+g_obs <- g0(W1, W2, W3)
+A <- rnorm(n_samp, g_obs$mu, sqrt(g_obs$sigma2))
+Y <- rbinom(n_samp, 1, Q0(A, W1, W2, W3))
+data_obs <- as_tibble(list(W1 = W1, W2 = W2, W3 = W3, A = A, Y = Y))
+
+# fit haldensify for conditional density estimation
+v_folds <- 5
+haldensify_fit <- haldensify(
+  A = data_obs$A,
+  W = data_obs %>% select(contains("W")),
+  grid_type = "equal_range",
+  n_bins = c(3, 5),
+  cv_folds = v_folds,
+  lambda_seq = exp(seq(-1, -10, length = 50))
+)
+haldensify_pred <- predict(
+  haldensify_fit,
+  new_A = data_obs$A,
+  new_W = data_obs %>% select(contains("W")),
+  lambda_select = "undersmooth"
+)
+
+# construct bootstrap samples and fit haldensify on each of these resamples
+# NOTE: pass in CV-selected tuning parameters and basis list for HAL fits
+n_boot <- 5
+boot_samples <- bootstraps(data_obs, times = n_boot)
+haldensify_pred_boot <- lapply(boot_samples$splits, function(data_split) {
+  # get bootstrap sample
+  data_boot <- as_tibble(data_split)
+
+  # fit HAL model on bootstrap sample
+  haldensify_boot <- haldensify(
+    A = data_boot$A,
+    W = data_boot %>% select(contains("W")),
+    grid_type = haldensify_fit$grid_type_cvselect,
+    n_bins = haldensify_fit$n_bins_cvselect,
+    cv_folds = v_folds,
+    lambda_seq = haldensify_fit$hal_fit$lambda_star,
+    hal_basis_list = haldensify_fit$hal_fit$basis_list
+   )
+
+  # extract conditional density estimates on bootstrap sample
+  haldensify_pred_boot <- predict(
+    haldensify_boot,
+    new_A = data_boot$A,
+    new_W = data_boot %>% select(contains("W")),
+    lambda_select = "all"
+  )
+
+  # return predicted CDE from HAL model on given bootstrap resample
+  return(haldensify_pred_boot)
+})
+
+# reduce predicted CDE from HAL models fit on bootstrap samples to only those
+# lambdas selected as part of the undersmoothed sequence
+haldensify_pred_boot_usm <- lapply(haldensify_pred_boot, function(hal_pred) {
+  # get subset of lambdas by matching column names
+  lambda_col_idx <- which(colnames(hal_pred) %in% colnames(haldensify_pred))
+  return(hal_pred[, lambda_col_idx])
+})
+
+# pack density estimates on original and bootstrap samples into array
+test <- abind(haldensify_pred,
+              unlist(haldensify_pred_boot_usm, recursive = FALSE),
+              along = 0)
+

--- a/tests/testthat/test-density_marginal.R
+++ b/tests/testthat/test-density_marginal.R
@@ -12,12 +12,12 @@ mod_haldensify <- haldensify(
 )
 
 # estimate density via Gaussian kernel density
-gauss_dens <- density(new_a)
+gauss_dens <- density(a)
 gauss_emprisk <- mean(-log(gauss_dens$y))
 
 # HAL predictions of density using support from the fitted density function
 hal_dens <- predict(mod_haldensify,
-  new_A = gauss_dens$x, new_W = rep(0, length(new_a))
+  new_A = gauss_dens$x, new_W = rep(0, length(a))
 )
 hal_emprisk <- mean(-log(hal_dens))
 

--- a/tests/testthat/test-density_marginal.R
+++ b/tests/testthat/test-density_marginal.R
@@ -1,0 +1,27 @@
+set.seed(76924)
+
+# simulate data: A ~ N(mu = 0, sd = 2)
+n_train <- 500
+a <- rnorm(n_train, 0, 2)
+
+# learn marginal density of A using HAL regression
+mod_haldensify <- haldensify(
+  A = a, W = NULL,
+  n_bins = c(5, 10),
+  lambda_seq = exp(seq(-1, -13, length = 200))
+)
+
+# estimate density via Gaussian kernel density
+gauss_dens <- density(new_a)
+gauss_emprisk <- mean(-log(gauss_dens$y))
+
+# HAL predictions of density using support from the fitted density function
+hal_dens <- predict(mod_haldensify,
+  new_A = gauss_dens$x, new_W = rep(0, length(new_a))
+)
+hal_emprisk <- mean(-log(hal_dens))
+
+# HAL-predicted density matches Gaussian kernel density closely in loss?
+test_that("Empirical risk of HAL density less than that of kernel density", {
+  expect_lt(hal_emprisk, gauss_emprisk)
+})

--- a/tests/testthat/test-density_standard.R
+++ b/tests/testthat/test-density_standard.R
@@ -1,8 +1,4 @@
 library(data.table)
-library(ggplot2)
-library(dplyr)
-library(hal9001)
-library(future)
 set.seed(76924)
 
 # simulate data: W ~ Rademacher and A|W ~ N(mu = \pm 1, sd = 0.5)
@@ -15,8 +11,7 @@ a <- rnorm(n_train, w, 0.5)
 mod_haldensify <- haldensify(
   A = a, W = w,
   n_bins = c(5, 10, 15),
-  lambda_seq = exp(seq(-1, -13, length = 200)),
-  use_future = FALSE
+  lambda_seq = exp(seq(-1, -13, length = 200))
 )
 
 # predictions to recover conditional density of A|W

--- a/tests/testthat/test-density_weights.R
+++ b/tests/testthat/test-density_weights.R
@@ -1,8 +1,5 @@
 library(data.table)
-library(ggplot2)
 library(dplyr)
-library(hal9001)
-library(future)
 set.seed(76921)
 
 # data simulation
@@ -14,7 +11,7 @@ sim_data_set <- function(n_obs = 1000, w_prob = 0.5, shift_delta = 0.5) {
   y <- a + w + rnorm(n_obs, mean = 0, sd = 1)
   data_in <- as.data.frame(cbind(y, a, ipc_delta, w, 1 / plogis(w))) %>%
     dplyr::filter(ipc_delta == 1) %>%
-    dplyr::select(-ipc_delta) %>%
+    select(-ipc_delta) %>%
     as.data.table()
   setnames(data_in, c("Y", "A", "W", "Weights"))
   return(data_in)
@@ -28,8 +25,7 @@ dens_lrn <- with(
     A = A, W = W,
     wts = Weights,
     n_bins = c(5, 10, 15),
-    lambda_seq = exp(seq(-1, -13, length = 200)),
-    use_future = FALSE
+    lambda_seq = exp(seq(-1, -13, length = 200))
   )
 )
 


### PR DESCRIPTION
This PR provides some streamlining of current functionality, improvements to the existing, and a new feature of two...see `NEWS.md` for a full list...

* adds a `basis_list` argument to `haldensify()` to allow pre-computed HAL basis functions to be passed in to the HAL model fitted on an augmented (repeated measures) dataset --- this should facilitate working with external cross-validation and bootstrap samples (e.g., via `rsample` https://rsample.tidymodels.org/reference/bootstraps.html).
* makes adjustments to facilitate working with undersmoothed density estimators with bootstrap resample HAL fits.
* improvements to various arguments in `haldensify()`