### PR TITLE
consistent use of `nfolds` for CV

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup R-check dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: any::rcmdcheck, tlverse::sl3
           needs: check
 
       - name: Check package

--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup R-check dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, github::tlverse/sl3
+          extra-packages: any::rcmdcheck, github::tlverse/sl3@master
           needs: check
 
       - name: Check package

--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup R-check dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, tlverse::sl3
+          extra-packages: any::rcmdcheck, github::tlverse/sl3
           needs: check
 
       - name: Check package

--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup R-check dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, github::tlverse/sl3@master
+          extra-packages: any::rcmdcheck
           needs: check
 
       - name: Check package

--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -14,7 +14,7 @@ jobs:
     name: Paper Draft
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build draft PDF
         uses: openjournals/openjournals-draft-action@master
         with:
@@ -22,7 +22,7 @@ jobs:
           # This should be the path to the paper within your repo.
           paper-path: paper/paper.md
       - name: Upload
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: paper
           # This is the output path where Pandoc will write the compiled

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,21 +19,19 @@ Maintainer: Nima Hejazi <nh@nimahejazi.org>
 Description: An algorithm for flexible conditional density estimation based on
     application of pooled hazard regression to an artificial repeated measures
     dataset constructed by discretizing the support of the outcome variable. To
-    facilitate non/semi-parametric estimation of the conditional density, the
-    highly adaptive lasso, a nonparametric regression function shown to
-    reliably estimate a large class of functions at a fast convergence rate, is
-    utilized.  The pooled hazards formulation implemented was first described
-    by Díaz and van der Laan (2011) <doi:10.2202/1557-4679.1356>. To complement
-    the conditional density estimation utilities, nonparametric inverse
-    probability weighted (IPW) estimators of the causal effects of additive
-    modified treatment policies are implemented, using the conditional density
-    estimation procedure to estimate the generalized propensity score. Per
-    Hejazi, Benkeser, Díaz, and van der Laan <>10.48550/arXiv.2205.05777>,
-    these nonparametric IPW estimators can be coupled with sieve estimation
-    (undersmoothing) of the generalized propensity score estimators to attain
-    the non/semi-parametric efficiency bound. This package is enhanced by the
-    Super Learner ensemble model in 'sl3', available for download from GitHub
-    using 'remotes::install_github("tlverse/sl3")'.
+    facilitate flexible estimation of the conditional density, the highly
+    adaptive lasso, a non-parametric regression function shown to estimate
+    cadlag (RCLL) functions at a suitably fast convergence rate, is used. The
+    use of pooled hazards regression for conditional density estimation as
+    implemented here was first described for by Díaz and van der Laan (2011)
+    <doi:10.2202/1557-4679.1356>. Building on the conditional density estimation
+    utilities, non-parametric inverse probability weighted (IPW) estimators of
+    the causal effects of additive modified treatment policies are implemented,
+    using conditional density estimation to estimate the generalized propensity
+    score. Non-parametric IPW estimators based on this can be coupled with sieve
+    estimation (undersmoothing) of the generalized propensity score to attain
+    the semi-parametric efficiency bound (per Hejazi, Benkeser, Díaz, and van
+    der Laan <doi:10.48550/arXiv.2205.05777>).
 Depends: R (>= 3.2.0)
 Imports:
     stats,
@@ -57,8 +55,6 @@ Suggests:
     rmarkdown,
     covr,
     future
-Enhances:
-    sl3 (>= 1.4.5)
 License: MIT + file LICENSE
 URL: https://github.com/nhejazi/haldensify
 BugReports: https://github.com/nhejazi/haldensify/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: haldensify
 Title: Highly Adaptive Lasso Conditional Density Estimation
-Version: 0.2.6
+Version: 0.2.7
 Authors@R: c(
     person("Nima", "Hejazi", email = "nh@nimahejazi.org",
            role = c("aut", "cre", "cph"),
@@ -31,7 +31,9 @@ Description: An algorithm for flexible conditional density estimation based on
     Hejazi, Benkeser, Díaz, and van der Laan <>10.48550/arXiv.2205.05777>,
     these nonparametric IPW estimators can be coupled with sieve estimation
     (undersmoothing) of the generalized propensity score estimators to attain
-    the non/semi-parametric efficiency bound.
+    the non/semi-parametric efficiency bound. This package is enhanced by the
+    Super Learner ensemble model in 'sl3', available for download from GitHub
+    using 'remotes::install_github("tlverse/sl3")'.
 Depends: R (>= 3.2.0)
 Imports:
     stats,
@@ -55,10 +57,12 @@ Suggests:
     rmarkdown,
     covr,
     future
+Enhances:
+    sl3 (>= 1.4.5)
 License: MIT + file LICENSE
 URL: https://github.com/nhejazi/haldensify
 BugReports: https://github.com/nhejazi/haldensify/issues
 Encoding: UTF-8
 VignetteBuilder: knitr
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 RdMacros: Rdpack

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,17 @@
+# haldensify 0.2.7
+
+As of September 2024
+* Continue fixing issues with incorrectly passing `n_folds` to `glmnet`, which
+  has argument `nfolds` (https://github.com/nhejazi/haldensify/issues/41)
+
 # haldensify 0.2.6
 
 As of February 2024:
 * Updated versions of `hal9001` and `origami`  in `DESCRIPTION` to match the
   latest CRAN releases, resolving bugs related to `Matrix` v1.6-2 as reported
   at <https://github.com/tlverse/hal9001/issues/109>.
+* Catch and fix incorrect internal references (as `n_folds`) to `glmnet` formal
+  argument `nfolds`, previously dropped by `hal9001`.
 
 # haldensify 0.2.5
 

--- a/R/confint.R
+++ b/R/confint.R
@@ -36,13 +36,12 @@
 #' # fit the IPW estimator
 #' est_ipw <- ipw_shift(
 #'   W = cbind(W1, W2, W3), A = A, Y = Y,
-#'   delta = 0.5, cv_folds = 2L,
+#'   delta = 0.5, cv_folds = 3L,
 #'   n_bins = 5L, bin_type = "equal_range",
 #'   lambda_seq = exp(seq(-1, -10, length = 100L)),
 #'   # arguments passed to hal9001::fit_hal()
-#'   max_degree = 3,
+#'   max_degree = 2,
 #'   smoothness_orders = 0,
-#'   num_knots = NULL,
 #'   reduce_basis = 1 / sqrt(n_obs)
 #' )
 #' confint(est_ipw)

--- a/R/haldensify.R
+++ b/R/haldensify.R
@@ -194,7 +194,7 @@ cv_haldensify <- function(fold,
 #'
 #' @examples
 #' # simulate data: W ~ U[-4, 4] and A|W ~ N(mu = W, sd = 0.5)
-#' set.seed(429153)
+#' set.seed(11249)
 #' n_train <- 50
 #' w <- runif(n_train, -4, 4)
 #' a <- rnorm(n_train, w, 0.5)
@@ -248,7 +248,7 @@ haldensify <- function(A, W,
 
   # extract n_bins/grid_type index that is empirical loss minimizer
   emp_risk_per_lambda <- lapply(select_out, `[[`, "emp_risks")
-  min_loss_idx <- lapply(emp_risk_per_lambda, which.min)
+  #min_loss_idx <- lapply(emp_risk_per_lambda, which.min)
   min_risk <- lapply(emp_risk_per_lambda, min)
   cv_selected_params <- tune_grid[which.min(min_risk), , drop = FALSE]
   cv_selected_fits <- select_out[[which.min(min_risk)]]
@@ -270,12 +270,12 @@ haldensify <- function(A, W,
   #       data (bootstrap); disadvantage: non-sample-split nuisance estimates
   if (!any(grepl("fit_control", names(fit_hal_args)))) {
     fit_hal_args$fit_control <- list(
-      cv_select = FALSE, weights = as.numeric(long_data$wts), n_folds = 1
+      cv_select = FALSE, weights = as.numeric(long_data$wts), nfolds = 1L
     )
   } else {
     fit_hal_args$fit_control$cv_select <- FALSE
     fit_hal_args$fit_control$weights <- as.numeric(long_data$wts)
-    fit_hal_args$fit_control$n_folds <- 1L
+    fit_hal_args$fit_control$nfolds <- 1L
   }
   fit_hal_args$X <- as.matrix(long_data[, -c("obs_id", "in_bin", "wts")])
   fit_hal_args$Y <- as.numeric(long_data$in_bin)
@@ -301,7 +301,7 @@ haldensify <- function(A, W,
 
 ###############################################################################
 
-#' Fit Conditional Density Estimation for a Sequence of HAL Models
+#' Fit Conditional Density Estimation over a Sequence of HAL Models
 #'
 #' @details Estimation of the conditional density of A|W via a cross-validated
 #'  highly adaptive lasso, used to estimate the conditional hazard of failure
@@ -350,6 +350,7 @@ haldensify <- function(A, W,
 #'
 #' @examples
 #' # simulate data: W ~ U[-4, 4] and A|W ~ N(mu = W, sd = 0.5)
+#' set.seed(11249)
 #' n_train <- 50
 #' w <- runif(n_train, -4, 4)
 #' a <- rnorm(n_train, w, 0.5)
@@ -368,7 +369,7 @@ fit_haldensify <- function(A, W,
                            smoothness_orders = 0L,
                            ...) {
   # capture dot arguments for reference
-  dot_args <- list(...)
+  #dot_args <- list(...)
 
   # re-format input data into long hazards structure
   reformatted_output <- format_long_hazards(

--- a/R/ipw_shift.R
+++ b/R/ipw_shift.R
@@ -47,6 +47,7 @@ utils::globalVariables(c("lambda_idx", "se_est", "l1_norm", "type"))
 #'
 #' @examples
 #' # simulate data
+#' set.seed(11249)
 #' n_obs <- 50
 #' W1 <- rbinom(n_obs, 1, 0.6)
 #' W2 <- rbinom(n_obs, 1, 0.2)
@@ -57,13 +58,12 @@ utils::globalVariables(c("lambda_idx", "se_est", "l1_norm", "type"))
 #' # fit the IPW estimator
 #' est_ipw <- ipw_shift(
 #'   W = cbind(W1, W2, W3), A = A, Y = Y,
-#'   delta = 0.5, cv_folds = 2L,
-#'   n_bins = 5L, bin_type = "equal_range",
+#'   delta = 0.5, cv_folds = 3L,
+#'   n_bins = 4L, bin_type = "equal_range",
 #'   lambda_seq = exp(seq(-1, -10, length = 100L)),
 #'   # arguments passed to hal9001::fit_hal()
-#'   max_degree = 3,
+#'   max_degree = 1L,
 #'   smoothness_orders = 0,
-#'   num_knots = NULL,
 #'   reduce_basis = 1 / sqrt(n_obs)
 #' )
 ipw_shift <- function(W, A, Y,
@@ -124,13 +124,13 @@ ipw_shift <- function(W, A, Y,
   # fit outcome mechanism Qn via CV-HAL
   Qn_fit <- hal9001::fit_hal(
     X = cbind(A, W), Y = Y,
-    max_degree = 5L,
-    smoothness_orders = 1L,
+    max_degree = 3L,
+    smoothness_orders = 0L,
     reduce_basis = 1 / sqrt(n_obs),
     family = outcome_family,
     fit_control = list(
       cv_select = TRUE,
-      n_folds = cv_folds
+      nfolds = cv_folds
     ),
     yolo = FALSE
   )

--- a/R/plots.R
+++ b/R/plots.R
@@ -31,7 +31,7 @@ utils::globalVariables(c("lambda", "risk"))
 #'   A = a, W = w, n_bins = 3,
 #'   lambda_seq = exp(seq(-1, -10, length = 50)),
 #'   # the following arguments are passed to hal9001::fit_hal()
-#'   max_degree = 3, reduce_basis = 0.1
+#'   max_degree = 2L, smoothness_orders = 0L, reduce_basis = 0.1
 #' )
 #' plot(haldensify_fit)
 plot.haldensify <- function(x, ..., type = c("risk", "density")) {

--- a/R/predict.R
+++ b/R/predict.R
@@ -58,7 +58,7 @@ utils::globalVariables(c("wts"))
 #' haldensify_fit <- haldensify(
 #'   A = a, W = w, n_bins = 10L, lambda_seq = exp(seq(-1, -10, length = 100)),
 #'   # the following arguments are passed to hal9001::fit_hal()
-#'   max_degree = 3, reduce_basis = 1 / sqrt(length(a))
+#'   max_degree = 2, smoothness_orders = 0L, reduce_basis = 1 / sqrt(length(a))
 #' )
 #' # predictions to recover conditional density of A|W
 #' new_a <- seq(-4, 4, by = 0.1)

--- a/R/utils.R
+++ b/R/utils.R
@@ -270,7 +270,7 @@ make_bins <- function(grid_var,
 #'
 #' @examples
 #' # simulate data: W ~ U[-4, 4] and A|W ~ N(mu = W, sd = 0.5)
-#' set.seed(429153)
+#' set.seed(11249)
 #' n_train <- 50
 #' w <- runif(n_train, -4, 4)
 #' a <- rnorm(n_train, w, 0.5)
@@ -279,7 +279,7 @@ make_bins <- function(grid_var,
 #' haldensify_fit <- haldensify(
 #'   A = a, W = w, n_bins = c(3, 5),
 #'   lambda_seq = exp(seq(-1, -15, length = 50L)),
-#'   max_degree = 3, reduce_basis = 0.1
+#'   max_degree = 2, smoothness_orders = 0, reduce_basis = 0.1
 #' )
 #' print(haldensify_fit)
 print.haldensify <- function(x, ...) {
@@ -326,6 +326,7 @@ print.haldensify <- function(x, ...) {
 #'
 #' @examples
 #' # simulate data
+#' set.seed(11249)
 #' n_obs <- 50
 #' W1 <- rbinom(n_obs, 1, 0.6)
 #' W2 <- rbinom(n_obs, 1, 0.2)
@@ -335,7 +336,7 @@ print.haldensify <- function(x, ...) {
 #' # fit the IPW estimator
 #' est_ipw_shift <- ipw_shift(
 #'   W = cbind(W1, W2), A = A, Y = Y,
-#'   delta = 0.5, n_bins = 3L, cv_folds = 2L,
+#'   delta = 0.5, n_bins = 3L, cv_folds = 3L,
 #'   lambda_seq = exp(seq(-1, -10, length = 100L)),
 #'   # arguments passed to hal9001::fit_hal()
 #'   max_degree = 1,

--- a/man/confint.ipw_haldensify.Rd
+++ b/man/confint.ipw_haldensify.Rd
@@ -45,13 +45,12 @@ Y <- rbinom(n_obs, 1, plogis(A + W1 + W2 - W3 - W1 * W3))
 # fit the IPW estimator
 est_ipw <- ipw_shift(
   W = cbind(W1, W2, W3), A = A, Y = Y,
-  delta = 0.5, cv_folds = 2L,
+  delta = 0.5, cv_folds = 3L,
   n_bins = 5L, bin_type = "equal_range",
   lambda_seq = exp(seq(-1, -10, length = 100L)),
   # arguments passed to hal9001::fit_hal()
-  max_degree = 3,
+  max_degree = 2,
   smoothness_orders = 0,
-  num_knots = NULL,
   reduce_basis = 1 / sqrt(n_obs)
 )
 confint(est_ipw)

--- a/man/fit_haldensify.Rd
+++ b/man/fit_haldensify.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/haldensify.R
 \name{fit_haldensify}
 \alias{fit_haldensify}
-\title{Fit Conditional Density Estimation for a Sequence of HAL Models}
+\title{Fit Conditional Density Estimation over a Sequence of HAL Models}
 \usage{
 fit_haldensify(
   A,
@@ -62,7 +62,7 @@ A \code{list}, containing density predictions for the sequence of
  sequence of fitted HAL models.
 }
 \description{
-Fit Conditional Density Estimation for a Sequence of HAL Models
+Fit Conditional Density Estimation over a Sequence of HAL Models
 }
 \details{
 Estimation of the conditional density of A|W via a cross-validated
@@ -71,6 +71,7 @@ Estimation of the conditional density of A|W via a cross-validated
 }
 \examples{
 # simulate data: W ~ U[-4, 4] and A|W ~ N(mu = W, sd = 0.5)
+set.seed(11249)
 n_train <- 50
 w <- runif(n_train, -4, 4)
 a <- rnorm(n_train, w, 0.5)

--- a/man/haldensify.Rd
+++ b/man/haldensify.Rd
@@ -96,7 +96,7 @@ Parallel evaluation of the cross-validation procedure to select tuning
 }
 \examples{
 # simulate data: W ~ U[-4, 4] and A|W ~ N(mu = W, sd = 0.5)
-set.seed(429153)
+set.seed(11249)
 n_train <- 50
 w <- runif(n_train, -4, 4)
 a <- rnorm(n_train, w, 0.5)

--- a/man/ipw_shift.Rd
+++ b/man/ipw_shift.Rd
@@ -65,6 +65,7 @@ IPW Estimator of the Causal Effects of Additive Modified Treatment Policies
 }
 \examples{
 # simulate data
+set.seed(11249)
 n_obs <- 50
 W1 <- rbinom(n_obs, 1, 0.6)
 W2 <- rbinom(n_obs, 1, 0.2)
@@ -75,13 +76,12 @@ Y <- rbinom(n_obs, 1, plogis(A + W1 + W2 - W3 - W1 * W3))
 # fit the IPW estimator
 est_ipw <- ipw_shift(
   W = cbind(W1, W2, W3), A = A, Y = Y,
-  delta = 0.5, cv_folds = 2L,
-  n_bins = 5L, bin_type = "equal_range",
+  delta = 0.5, cv_folds = 3L,
+  n_bins = 4L, bin_type = "equal_range",
   lambda_seq = exp(seq(-1, -10, length = 100L)),
   # arguments passed to hal9001::fit_hal()
-  max_degree = 3,
+  max_degree = 1L,
   smoothness_orders = 0,
-  num_knots = NULL,
   reduce_basis = 1 / sqrt(n_obs)
 )
 }

--- a/man/plot.haldensify.Rd
+++ b/man/plot.haldensify.Rd
@@ -35,7 +35,7 @@ haldensify_fit <- haldensify(
   A = a, W = w, n_bins = 3,
   lambda_seq = exp(seq(-1, -10, length = 50)),
   # the following arguments are passed to hal9001::fit_hal()
-  max_degree = 3, reduce_basis = 0.1
+  max_degree = 2L, smoothness_orders = 0L, reduce_basis = 0.1
 )
 plot(haldensify_fit)
 }

--- a/man/predict.haldensify.Rd
+++ b/man/predict.haldensify.Rd
@@ -76,7 +76,7 @@ a <- rnorm(n_train, w, 0.5)
 haldensify_fit <- haldensify(
   A = a, W = w, n_bins = 10L, lambda_seq = exp(seq(-1, -10, length = 100)),
   # the following arguments are passed to hal9001::fit_hal()
-  max_degree = 3, reduce_basis = 1 / sqrt(length(a))
+  max_degree = 2, smoothness_orders = 0L, reduce_basis = 1 / sqrt(length(a))
 )
 # predictions to recover conditional density of A|W
 new_a <- seq(-4, 4, by = 0.1)

--- a/man/print.haldensify.Rd
+++ b/man/print.haldensify.Rd
@@ -23,7 +23,7 @@ The \code{print} method for objects of class \code{haldensify}
 }
 \examples{
 # simulate data: W ~ U[-4, 4] and A|W ~ N(mu = W, sd = 0.5)
-set.seed(429153)
+set.seed(11249)
 n_train <- 50
 w <- runif(n_train, -4, 4)
 a <- rnorm(n_train, w, 0.5)
@@ -32,7 +32,7 @@ a <- rnorm(n_train, w, 0.5)
 haldensify_fit <- haldensify(
   A = a, W = w, n_bins = c(3, 5),
   lambda_seq = exp(seq(-1, -15, length = 50L)),
-  max_degree = 3, reduce_basis = 0.1
+  max_degree = 2, smoothness_orders = 0, reduce_basis = 0.1
 )
 print(haldensify_fit)
 }

--- a/man/print.ipw_haldensify.Rd
+++ b/man/print.ipw_haldensify.Rd
@@ -26,6 +26,7 @@ The \code{print} method for objects of class \code{ipw_haldensify}
 }
 \examples{
 # simulate data
+set.seed(11249)
 n_obs <- 50
 W1 <- rbinom(n_obs, 1, 0.6)
 W2 <- rbinom(n_obs, 1, 0.2)
@@ -35,7 +36,7 @@ Y <- rbinom(n_obs, 1, plogis(3 * A + W1 + W2 - W1 * W2))
 # fit the IPW estimator
 est_ipw_shift <- ipw_shift(
   W = cbind(W1, W2), A = A, Y = Y,
-  delta = 0.5, n_bins = 3L, cv_folds = 2L,
+  delta = 0.5, n_bins = 3L, cv_folds = 3L,
   lambda_seq = exp(seq(-1, -10, length = 100L)),
   # arguments passed to hal9001::fit_hal()
   max_degree = 1,

--- a/tests/testthat/test-density_standard.R
+++ b/tests/testthat/test-density_standard.R
@@ -46,8 +46,8 @@ haldensify_fit_cntrl <- haldensify(
   A = a, W = w,
   n_bins = c(3, 5),
   lambda_seq = exp(seq(-1, -13, length = n_lambda)),
-  max_degree = 2,
-  fit_control = list(cv_select = TRUE, n_folds = 3L, use_min = TRUE)
+  max_degree = 1L,
+  fit_control = list(cv_select = TRUE, nfolds = 3L, use_min = TRUE)
 )
 cv_lambda_idx <- haldensify_fit_cntrl$cv_tuning_results$lambda_loss_min_idx
 

--- a/tests/testthat/test-ipw_est.R
+++ b/tests/testthat/test-ipw_est.R
@@ -17,7 +17,7 @@ est_ipw <- ipw_shift(
   W = data_obs[, c("W1", "W2", "W3")],
   A = data_obs$A, Y = data_obs$Y,
   delta = delta,
-  n_bins = 10L,
+  n_bins = 5L,
   cv_folds = 3L,
   lambda_seq = exp(seq(-1, -8, length = 100L)),
   ## arguments passed to hal9001::fit_hal()

--- a/tests/testthat/test-ratio_covar.R
+++ b/tests/testthat/test-ratio_covar.R
@@ -1,4 +1,5 @@
 library(data.table)
+#library(sl3)
 set.seed(76924)
 
 # HAL for A ~ W1/W2, considering W2 as continuous and discrete

--- a/vignettes/intro_haldensify.Rmd
+++ b/vignettes/intro_haldensify.Rmd
@@ -163,11 +163,11 @@ binning strategy that accommodates creating such a large number of bins.
 haldensify_fit <- haldensify(
   A = example_data$A,
   W = example_data$W,
-  n_bins = c(5, 10),
+  n_bins = c(4, 6, 8),
   grid_type = "equal_range",
   lambda_seq = exp(seq(-0.1, -10, length = 300)),
   # the following are passed to hal9001::fit_hal() internally
-  max_degree = 2,
+  max_degree = 1,
   reduce_basis = 1 / sqrt(n_obs)
 )
 ```
@@ -344,13 +344,13 @@ performance, see @hejazi2022efficient.
 est_ipw <- ipw_shift(
   W = dat_obs$W, A = dat_obs$A, Y = dat_obs$Y,
   delta = 2,
-  cv_folds = 2L,
-  n_bins = 5L,
+  cv_folds = 5L,
+  n_bins = 4L,
   bin_type = "equal_range",
   selector_type = "all",
   lambda_seq = exp(seq(-1, -10, length = 500L)),
   # arguments passed to hal9001::fit_hal()
-  max_degree = 2,
+  max_degree = 1,
   reduce_basis = 1 / sqrt(n_obs)
 )
 confint(est_ipw)
@@ -365,4 +365,3 @@ with the latter guaranteed to solve an estimating function required for the
 characterization of asymptotically efficient estimators.
 
 ## References
-


### PR DESCRIPTION
fixes issue of using legacy argument `n_folds` of `hal9001` by replacing with `glmnet` arugment `nfolds` throughout; also resolves some package check/build warnings